### PR TITLE
Fix ruff exclude

### DIFF
--- a/changes/212.fixed
+++ b/changes/212.fixed
@@ -1,0 +1,1 @@
+Fixed ruff excludes to use per-file excludes instead of global excludes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,6 @@ supported_nautobot_versions = [
 [tool.ruff]
 line-length = 120
 target-version = "py38"
-exclude = [
-    "migrations",
-]
 
 [tool.ruff.lint]
 select = [
@@ -137,8 +134,24 @@ ignore = [
     "D212",  # Multi-line docstring summary should start at the first line
     "D213",  # Multi-line docstring summary should start at the second line
 
-    # Produces a lot of issues in the current codebase.
+    # Produces issues in the current codebase.
     "D401",  # First line of docstring should be in imperative mood
+    "D407",  # Missing dashed underline after section
+    "D416",  # Section name ends in colon
+]
+
+[tool.ruff.per-file-ignores]
+"nautobot_firewall_models/migrations/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
+]
+"nautobot_firewall_models/tests/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,7 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 ignore = [
     # warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
@@ -145,16 +142,10 @@ convention = "google"
 
 [tool.ruff.per-file-ignores]
 "nautobot_firewall_models/migrations/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 "nautobot_firewall_models/tests/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,9 @@ ignore = [
     "D416",  # Section name ends in colon
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.per-file-ignores]
 "nautobot_firewall_models/migrations/*" = [
     "D1",  # pydocstyle


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Fixed ruff excludes to use per-file excludes instead of global excludes.
- Align ruff with previous pydocstyle checks.
