### PR TITLE
Update .cookiecutter.json

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -14,7 +14,7 @@
         "max_nautobot_version": "2.9999",
         "camel_name": "NautobotFirewallModels",
         "project_short_description": "Nautobot App to model firewall and security objects. Allows users to model policies in a vendor-neutral manner and use that data to drive network security automation",
-        "model_class_name": "None",
+        "model_class_name": "IPRange",
         "open_source_license": "Apache-2.0",
         "docs_base_url": "https://docs.nautobot.com",
         "docs_app_url": "https://docs.nautobot.com/projects/firewall-models/en/latest",

--- a/changes/281.housekeeping
+++ b/changes/281.housekeeping
@@ -1,0 +1,1 @@
+Changed model_class_name in .cookiecutter.json to a valid model to help with drift management.


### PR DESCRIPTION
Due to the way that Drift Manager uses the .cookiecutter.json file, we need to change the model_class_name to a valid model in Firewall models to help us track drift in files that would be removed if the model_class_name=None.