### PR TITLE
Removed the filter_address method from IPRangeFilterSet (Issue #269)

### DIFF
--- a/changes/269.removed
+++ b/changes/269.removed
@@ -1,0 +1,1 @@
+Removed the filter_address method from IPRangeFilterSet to resolve issues with searching for IPRange objects through the GUI and API.

--- a/nautobot_firewall_models/filters.py
+++ b/nautobot_firewall_models/filters.py
@@ -2,7 +2,6 @@
 
 import django_filters
 from django.contrib.contenttypes.fields import GenericRelation
-from django.core.exceptions import ValidationError
 from nautobot.apps.filters import (
     MultiValueCharFilter,
     NaturalKeyOrPKMultipleChoiceFilter,
@@ -30,11 +29,9 @@ class IPRangeFilterSet(BaseFilterSet, NautobotFilterSet):  # pylint: disable=too
     """Filter for IPRange."""
 
     start_address = MultiValueCharFilter(
-        method="filter_address",
         label="Address",
     )
     end_address = MultiValueCharFilter(
-        method="filter_address",
         label="Address",
     )
 
@@ -44,13 +41,6 @@ class IPRangeFilterSet(BaseFilterSet, NautobotFilterSet):  # pylint: disable=too
         model = models.IPRange
 
         fields = [i.name for i in model._meta.get_fields() if not isinstance(i, GenericRelation)]
-
-    def filter_address(self, queryset, name, value):  # pylint: disable=unused-argument
-        """Filter method for start & end addresses."""
-        try:
-            return queryset.net_in(value)
-        except ValidationError:
-            return queryset.none()
 
 
 class FQDNFilterSet(BaseFilterSet, NautobotFilterSet):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Firewall Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #269

## What's Changed

Removed the filter_address method from IPRangeFilterSet to resolve issues with searching for IPRange objects through the GUI and API.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

