### PR TITLE
fix: Prefix names starting with numbers with an underscore

### DIFF
--- a/changes/319.fixed
+++ b/changes/319.fixed
@@ -1,0 +1,1 @@
+Fixed names starting with numbers by prefixing with an underscore.

--- a/nautobot_firewall_models/utils/capirca.py
+++ b/nautobot_firewall_models/utils/capirca.py
@@ -33,11 +33,17 @@ def _slugify(value):
     dashes to single dashes. Remove characters that aren't alphanumerics,
     underscores, or hyphens. Convert to lowercase. Also strip leading and
     trailing whitespace, dashes, and underscores.
+    Also adds a trailing underscore to names starting with an number to circumvent a bug in the Capirca/Aerleon parser.
     """
     value = str(value)
     value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
     value = re.sub(r"[^\w\s-]", "", value)
-    return re.sub(r"[-\s]+", "-", value).strip("-_")
+    value = re.sub(r"[-\s]+", "-", value).strip("-_")
+
+    if value[:1].isnumeric():
+        value = "_" + value
+
+    return value
 
 
 def _list_slugify(values):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Firewall Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #319 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

It prefixes names starting with a number with an underscore.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
