### PR TITLE
fix: Slugify address references in address groups

### DIFF
--- a/changes/320.fixed
+++ b/changes/320.fixed
@@ -1,0 +1,1 @@
+Fixed the reference of addresses in address groups with complex names.

--- a/nautobot_firewall_models/utils/capirca.py
+++ b/nautobot_firewall_models/utils/capirca.py
@@ -431,7 +431,9 @@ class PolicyToCapirca:
                 )
         for name, addresses in self.address_group.items():
             name = _slugify(name)
-            networkdata[name] = _clean_list(addresses, True)
+            # Note: This list only contains address names. Those names are slugified above,
+            # so we also have to slugify the list.
+            networkdata[name] = _list_slugify(_clean_list(addresses, True))
 
         servicedata = {}
         servicedata_ports = {}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Firewall Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #320 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

We are now also slugify the references in address groups to addresses, since address names are slugified anyways. 

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
