### PR TITLE
Fix Upstream Testing

### DIFF
--- a/nautobot_firewall_models/tests/test_ui_views.py
+++ b/nautobot_firewall_models/tests/test_ui_views.py
@@ -393,6 +393,7 @@ class CapircaPolicyUIViewTest(ViewTestCases.GetObjectViewTestCase, ViewTestCases
     """Test the Policy viewsets."""
 
     model = CapircaPolicy
+    allowed_number_of_tree_queries_per_view_type = {"retrieve": 1}
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Caprica relies on Device, which has the query to locations.

<!--
    Thank you for your interest in contributing to Nautobot Firewall Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: N/A
## What's Changed

Added `allowed_number_of_tree_queries_per_view_type = {"retrieve": 1}` after the recent change to Nautobot enforcing the number of tree queries.

Here is where the default for tests was changed: https://github.com/nautobot/nautobot/pull/7810

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
